### PR TITLE
Specify python version

### DIFF
--- a/notification.py
+++ b/notification.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import json
 import urllib2
 import os


### PR DESCRIPTION
This throws a syntax error on Arch since it defaults to Python 3.
Specifying `python2` fixes this issue
